### PR TITLE
api update v3 to v5

### DIFF
--- a/app/scenes/SceneBrowser.js
+++ b/app/scenes/SceneBrowser.js
@@ -285,6 +285,7 @@ SceneSceneBrowser.loadDataRequest = function()
 	    xmlHttp.open("GET", theUrl, true);
 		xmlHttp.timeout = SceneSceneBrowser.loadingDataTimeout;
 		xmlHttp.setRequestHeader('Client-ID', 'anwtqukxvrtwxb4flazs2lqlabe3hqv');
+		xmlHttp.setRequestHeader('Accept', 'application/vnd.twitchtv.v5+json');
 	    xmlHttp.send(null);
 	}
 	catch (error)

--- a/app/scenes/SceneChannel.js
+++ b/app/scenes/SceneChannel.js
@@ -439,6 +439,7 @@ SceneSceneChannel.updateStreamInfo = function()
     xmlHttp.open("GET", 'https://api.twitch.tv/kraken/streams/' + SceneSceneBrowser.selectedChannel, true);
 	xmlHttp.timeout = 10000;
 	xmlHttp.setRequestHeader('Client-ID', 'anwtqukxvrtwxb4flazs2lqlabe3hqv');
+	xmlHttp.setRequestHeader('Accept', 'application/vnd.twitchtv.v5+json');
     xmlHttp.send(null);
 };
 
@@ -567,7 +568,8 @@ SceneSceneChannel.loadDataRequest = function()
 		};
 	    xmlHttp.open("GET", theUrl, true);
 		xmlHttp.timeout = SceneSceneChannel.loadingDataTimeout;
-		xmlHttp.setRequestHeader('Client-ID', 'anwtqukxvrtwxb4flazs2lqlabe3hqv');
+		xmlHttp.setRequestHeader('Client-ID', 'kimne78kx3ncx6brgo4mv6wki5h1ko');
+		xmlHttp.setRequestHeader('Accept', 'application/vnd.twitchtv.v5+json');
 	    xmlHttp.send(null);
 	}
 	catch (error)


### PR DESCRIPTION
It seems like they are not supporting the access token endpoint for 3rd parties anymore. It's still possible to use it with twitch's client id.